### PR TITLE
3 refactor optimize external ai api client and request flow

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,12 @@ dependencyManagement {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
     /* test
      */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     /* Observability

--- a/build.gradle
+++ b/build.gradle
@@ -40,10 +40,12 @@ dependencies {
      */
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
     /* Observability
+     */
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-     */
+
 
     /*  GCP Storage
      */
@@ -120,4 +122,8 @@ clean {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+springBoot{
+    buildInfo()
 }

--- a/src/main/java/org/woojukang/remixlab/domain/creation/controller/CreationController.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/controller/CreationController.java
@@ -20,6 +20,7 @@ import org.woojukang.remixlab.domain.creation.dto.response.plot.InitPlotResultRe
 import org.woojukang.remixlab.domain.creation.facade.CreationFacade;
 import org.woojukang.remixlab.global.config.exception.dto.ApiResult;
 import org.woojukang.remixlab.query.creation.dto.response.ShowMyCreationResponse;
+import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/v1/creation")
@@ -51,16 +52,17 @@ public class CreationController {
     @PostMapping("/make/photo")
     @Operation(summary = "AI 사진 생성",
             description = "AI를 통해 사진을 생성합니다. 이때 , 플룻을 기반으로 생성합니다. \n /make/plot API의 호출 결과에서 creationId를 제외한 나머지를 그대로 requestBody에 넣어주시면 됩니다." )
-    public ResponseEntity<ApiResult<InitPhotoResultResponse>> makePhoto
+    public Mono<ResponseEntity<ApiResult<InitPhotoResultResponse>>> makePhoto
             (@RequestBody InitPhotoRequest initPhotoRequest,
              @AuthenticationPrincipal UserDetails userDetails){
 
-        return ResponseEntity
-                .status(HttpStatus
-                        .CREATED)
-                .body(ApiResult
-                        .success(creationFacade
-                                .makePhotos(initPhotoRequest,userDetails.getUsername())));
+        return creationFacade
+                .makePhotosReactive(initPhotoRequest,
+                        userDetails.getUsername())
+                .map(result
+                        -> ResponseEntity
+                        .status(HttpStatus.CREATED)
+                        .body(ApiResult.success(result)));
 
     }
 
@@ -68,18 +70,16 @@ public class CreationController {
     @PostMapping("/text/make/photo")
     @Operation(summary = "텍스트로 AI 사진생성",
             description = "AI를 통해 사진을 생성합니다. 이때 , 사용자의 입력을 기반으로 생성합니다.")
-    public ResponseEntity<ApiResult<DirectPhotoResultResponse>> makePhotoByText
+    public Mono<ResponseEntity<ApiResult<DirectPhotoResultResponse>>> makePhotoByText
             (@RequestBody DirectPhotoRequest directPhotoRequest,
              @AuthenticationPrincipal UserDetails userDetails) {
 
-        return ResponseEntity
-                .status(HttpStatus
-                        .CREATED)
-                .body(ApiResult
-                        .success(creationFacade
-                                .makePhotoDirectly(directPhotoRequest,
-                                        userDetails
-                                                .getUsername())));
+        return creationFacade
+                .makePhotoDirectlyReactive(directPhotoRequest, userDetails.getUsername())
+                .map(result ->
+                        ResponseEntity
+                                .status(HttpStatus.CREATED)
+                                .body(ApiResult.success(result)));
 
     }
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/controller/CreationController.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/controller/CreationController.java
@@ -3,6 +3,7 @@ package org.woojukang.remixlab.domain.creation.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,6 +27,7 @@ import reactor.core.publisher.Mono;
 @RequestMapping("/api/v1/creation")
 @RequiredArgsConstructor
 @Tag(name = "생성 API",description = "생성 관련 API")
+@Slf4j
 public class CreationController {
 
     private final CreationFacade creationFacade;
@@ -34,18 +36,15 @@ public class CreationController {
     @PostMapping("/make/plot")
     @Operation(summary = "AI 플롯 생성",
             description = "AI를 통해 이야기 플롯을 생성합니다.")
-    public ResponseEntity<ApiResult<InitPlotResultResponse>> makePlot
+    public Mono<ResponseEntity<ApiResult<InitPlotResultResponse>>> makePlot
             (@RequestBody InitPlotRequest initPlotRequest,
              @AuthenticationPrincipal UserDetails userDetails){
 
-        return ResponseEntity
-                .status(HttpStatus
-                        .CREATED)
-                .body(ApiResult
-                        .success(creationFacade
-                                .makePlot(userDetails
-                                                .getUsername(),
-                                        initPlotRequest)));
+        log.info("makePlot entered, principal={}", userDetails);
+        return creationFacade.makePlotReactive(userDetails.getUsername(), initPlotRequest)
+                .map(result ->
+                        ResponseEntity.status(HttpStatus.CREATED)
+                                .body(ApiResult.success(result)));
     }
 
     // AI 사진 생성 API
@@ -87,34 +86,31 @@ public class CreationController {
     @PostMapping("/make/video")
     @Operation(summary = "비디오 생성기",
             description = "사용자가 선택한 사진을 기반으로 비디오를 생성합니다.\n이때 , 생성된 비디오의 url은 생성하지 않으며 비디오 생성을 요청만합니다. ")
-    public ResponseEntity<ApiResult<InitVideoResponse>> makeVideo
+    public Mono<ResponseEntity<ApiResult<InitVideoResponse>>> makeVideo
     (@RequestBody InitVideoRequest initVideoRequest,
      @AuthenticationPrincipal UserDetails userDetails){
 
-        return ResponseEntity
-                .status(HttpStatus
-                        .CREATED)
-                .body(ApiResult
-                        .success(creationFacade
-                                .makeVideoByPhotos(initVideoRequest,
-                                        userDetails.getUsername())));
+        return creationFacade
+                .makeVideoByPhotosReactive(initVideoRequest, userDetails.getUsername())
+                .map(result -> ResponseEntity
+                        .status(HttpStatus.CREATED)
+                        .body(ApiResult
+                                .success(result)));
     }
 
     @PostMapping("/text/make/video")
     @Operation(summary = "비디오 생성기",
             description = "텍스트 기반으로 비디오를 생성합니다.\n이때 , 생성된 비디오의 url은 생성하지 않으며 비디오 생성을 요청만합니다.")
-    public ResponseEntity<ApiResult<InitVideoResponse>> makeVideoByText
+    public Mono<ResponseEntity<ApiResult<InitVideoResponse>>> makeVideoByText
             (@RequestBody DirectVideoRequest directVideoRequest,
              @AuthenticationPrincipal UserDetails userDetails){
 
-        return ResponseEntity
-                .status(HttpStatus
-                        .CREATED)
-                .body(ApiResult
-                        .success(creationFacade
-                                .makeVideoByText(userDetails
-                                        .getUsername(),
-                                        directVideoRequest)));
+        return creationFacade.
+                makeVideoByTextReactive(userDetails.getUsername(),directVideoRequest)
+                .map(result -> ResponseEntity
+                        .status(HttpStatus.CREATED)
+                        .body(ApiResult
+                                .success(result)));
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
@@ -38,6 +38,7 @@ import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResp
 import org.woojukang.remixlab.query.creation.service.CreationQueryService;
 import org.woojukang.remixlab.query.creation.service.PlotQueryService;
 import org.woojukang.remixlab.query.user.service.UserQueryService;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -59,11 +60,37 @@ public class CreationFacade {
 
     private final PhotoGenerationMetrics photoGenerationMetrics;
 
+    /*
+    WebFlux Block 메소드
+     */
+
+    @Transactional
+    public InitPlotResultResponse makePlot(String username,InitPlotRequest initPlotRequest){
+        return makePlotReactive(username,initPlotRequest)
+                .block();
+    }
+
+    @Transactional
+    public InitPhotoResultResponse makePhotos
+            (InitPhotoRequest initPhotoRequest,
+             String username) {
+
+        return makePhotosReactive(initPhotoRequest,username)
+                .block();
+    }
+
+    @Transactional
+    public DirectPhotoResultResponse makePhotoDirectly
+            (DirectPhotoRequest directPhotoRequest,
+             String username){
+
+        return makePhotoDirectlyReactive(directPhotoRequest,username).block();
+    }
+
     /* plot 생성기
     */
 
-    @Transactional
-    public InitPlotResultResponse makePlot
+    public Mono<InitPlotResultResponse> makePlotReactive
     (String username,
      InitPlotRequest initPlotRequest){
 
@@ -82,112 +109,103 @@ public class CreationFacade {
                         .findByUsername(username),
                         initPlotRequest);
 
-        // plot 생성하기
-        InitPlotResponse initPlotResponse = creationService
-                .initPlot(aiClientRequest);
+        return creationService.initPlot(aiClientRequest)
 
+                .map(initPlotResponse -> {
 
-        // plot 저장하기
-        plotService
-                .savePlot(creation,
-                        initPlotResponse);
+                    plotService.savePlot(creation, initPlotResponse);
 
-        // 퀘스트 여부 확인하기
-        questFacade.onPlotCreated(username);
+                    questFacade.onPlotCreated(username);
 
-        // response 응답 생성하기
-        return InitPlotResultResponse.from(creation.getId(),initPlotResponse);
+                    return InitPlotResultResponse.from(
+                            creation.getId(),
+                            initPlotResponse
+                    );
+                });
     }
+
 
     /* photo 생성기
     */
 
-    @Transactional
-    public DirectPhotoResultResponse makePhotoDirectly
-            (DirectPhotoRequest directPhotoRequest,
-             String username){
+    // Text 기반 사진 생성
+    public Mono<DirectPhotoResultResponse> makePhotoDirectlyReactive(
+            DirectPhotoRequest directPhotoRequest,
+            String username){
 
-        // 프롬프트 결합 후 , requestDTO 생성
         AiClientRequest aiClientRequest =
                 new AiClientRequest(directPhotoRequest.prompt());
 
-        // 사진 생성기 실행 ( 렌더링 X )
-        DirectPhotoResponse directPhotoResponse =
-                creationService.makePhotoFromText(directPhotoRequest);
+        return creationService.makePhotoFromText(directPhotoRequest)
 
-        // User 가져오기
-        User user = userQueryService
-                .findByUsername(username);
+                .map(directPhotoResponse -> {
 
-        // creation 생성후 , photo 생성하기
-        Creation creation = creationService
-                .makeCreationDirect(user,
-                        aiClientRequest);
+                    User user = userQueryService
+                            .findByUsername(username);
 
-        // photo 객체 저장 및 response 생성
-        DirectPhotoResultResponse directPhotoResultResponse =
-                photoService
-                        .saveDirectPhoto(creation,
-                                directPhotoResponse);
+                    Creation creation = creationService
+                            .makeCreationDirect(user, aiClientRequest);
 
-        // 퀘스트 체크
-        questFacade.onPhotoCreated(username);
+                    DirectPhotoResultResponse result =
+                            photoService.saveDirectPhoto(
+                                    creation,
+                                    directPhotoResponse
+                            );
 
-        return directPhotoResultResponse;
+                    questFacade.onPhotoCreated(username);
+
+                    return result;
+                });
     }
 
 
-    @Transactional
-    public InitPhotoResultResponse makePhotos
-    (InitPhotoRequest initPhotoRequest,
-     String username) {
+    // Plot 기반 사진 생성
+    public Mono<InitPhotoResultResponse> makePhotosReactive(
+            InitPhotoRequest initPhotoRequest,
+            String username) {
 
-        // 사진 생성 전용 메트릭 시작
         Timer.Sample sample = photoGenerationMetrics.start();
 
-        try {
-            // 프롬프트 결합후 , request DTO 생성
-            AiClientRequest aiClientRequest =
-                    new AiClientRequest(String.format(
-                            InitPromptTemplate
-                                    .INIT_IMAGE_PROMPT_MAKING
-                                    .getTemplate()
-                                    .replace("{user_input}",
-                                            creationService.requestToString(initPhotoRequest))));
+        AiClientRequest aiClientRequest =
+                new AiClientRequest(String.format(
+                        InitPromptTemplate
+                                .INIT_IMAGE_PROMPT_MAKING
+                                .getTemplate()
+                                .replace("{user_input}",
+                                        creationService.requestToString(initPhotoRequest))
+                ));
 
-            // 사진 생성을 위한 프롬프트 생성기 실행 ( gpt API )
-            InitPhotoResponse initPhotoResponse =
-                    creationService.initPhotos(aiClientRequest);
+        return creationService.initPhotos(aiClientRequest)
+                .flatMap(initPhotoResponse ->
+                        creationService.initPhotoRender(
+                                InitPhotoRenderRequest.from(initPhotoResponse)
+                        )
+                )
+                .map(initPhotoRenderResponse -> {
 
-            // 사진 생성 프롬프트로 사진 생성하기 ( gpt API )
-            InitPhotoRenderResponse initPhotoRenderResponse = creationService
-                    .initPhotoRender(InitPhotoRenderRequest
-                            .from(initPhotoResponse));
+                    Creation creation = plotQueryService
+                            .findCreationByPlot(
+                                    plotQueryService
+                                            .findByTitle(initPhotoRequest.title())
+                                            .getId()
+                            );
 
+                    List<Photo> photoList = photoService
+                            .savePhotos(creation,
+                                    initPhotoRenderResponse,
+                                    initPhotoRequest);
 
-            // plot으로부터 creation 호출
-            Creation creation = plotQueryService
-                    .findCreationByPlot(plotQueryService
-                            .findByTitle(initPhotoRequest.title()).getId());
+                    photoGenerationMetrics.success(); // throughput 증가
 
-            // creation 호출 후 , Photo 객체 생성후 저장하기
-            List<Photo> photoList = photoService
-                    .savePhotos(creation,
-                            initPhotoRenderResponse,
-                            initPhotoRequest);
-
-            // response 생성하기
-            return photoService.makeResult(photoList);
-
-        } finally {
-            photoGenerationMetrics.stop(sample);
-        }
-
+                    return photoService.makeResult(photoList);
+                })
+                .doOnError(e -> photoGenerationMetrics.fail()) //  실패 throughput
+                .doFinally(signal -> photoGenerationMetrics.stop(sample));
     }
 
 
-
-    /* Video 생성하기
+    /*
+    Video 생성하기
      */
 
     @Transactional

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
@@ -70,22 +70,8 @@ public class CreationFacade {
                 .block();
     }
 
-    @Transactional
-    public InitPhotoResultResponse makePhotos
-            (InitPhotoRequest initPhotoRequest,
-             String username) {
 
-        return makePhotosReactive(initPhotoRequest,username)
-                .block();
-    }
 
-    @Transactional
-    public DirectPhotoResultResponse makePhotoDirectly
-            (DirectPhotoRequest directPhotoRequest,
-             String username){
-
-        return makePhotoDirectlyReactive(directPhotoRequest,username).block();
-    }
 
     /* plot 생성기
     */
@@ -160,6 +146,7 @@ public class CreationFacade {
 
 
     // Plot 기반 사진 생성
+    @Transactional
     public Mono<InitPhotoResultResponse> makePhotosReactive(
             InitPhotoRequest initPhotoRequest,
             String username) {

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
@@ -1,5 +1,6 @@
 package org.woojukang.remixlab.domain.creation.facade;
 
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Component;
@@ -30,6 +31,7 @@ import org.woojukang.remixlab.domain.video.service.VideoService;
 import org.woojukang.remixlab.global.client.ai.dto.request.AiClientRequest;
 import org.woojukang.remixlab.global.client.ai.dto.request.prompt.template.InitPromptTemplate;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
+import org.woojukang.remixlab.global.metrics.PhotoGenerationMetrics;
 import org.woojukang.remixlab.query.creation.dto.request.ShowPlotWithDetailRequest;
 import org.woojukang.remixlab.query.creation.dto.response.ShowMyCreationResponse;
 import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResponse;
@@ -55,6 +57,7 @@ public class CreationFacade {
 
     private final QuestFacade questFacade;
 
+    private final PhotoGenerationMetrics photoGenerationMetrics;
 
     /* plot 생성기
     */
@@ -139,41 +142,47 @@ public class CreationFacade {
     (InitPhotoRequest initPhotoRequest,
      String username) {
 
-        // 프롬프트 결합후 , request DTO 생성
-        AiClientRequest aiClientRequest =
-                new AiClientRequest(String.format(
-                        InitPromptTemplate
-                                .INIT_IMAGE_PROMPT_MAKING
-                                .getTemplate()
-                                .replace("{user_input}",
-                                        creationService.requestToString(initPhotoRequest))));
+        // 사진 생성 전용 메트릭 시작
+        Timer.Sample sample = photoGenerationMetrics.start();
 
-        // 사진 생성을 위한 프롬프트 생성기 실행 ( gpt API )
-        InitPhotoResponse initPhotoResponse =
-                creationService.initPhotos(aiClientRequest);
+        try {
+            // 프롬프트 결합후 , request DTO 생성
+            AiClientRequest aiClientRequest =
+                    new AiClientRequest(String.format(
+                            InitPromptTemplate
+                                    .INIT_IMAGE_PROMPT_MAKING
+                                    .getTemplate()
+                                    .replace("{user_input}",
+                                            creationService.requestToString(initPhotoRequest))));
 
-        // 사진 생성 프롬프트로 사진 생성하기 ( gpt API )
-        InitPhotoRenderResponse initPhotoRenderResponse =  creationService
-                .initPhotoRender(InitPhotoRenderRequest
-                        .from(initPhotoResponse));
+            // 사진 생성을 위한 프롬프트 생성기 실행 ( gpt API )
+            InitPhotoResponse initPhotoResponse =
+                    creationService.initPhotos(aiClientRequest);
 
-
-        // plot으로부터 creation 호출
-        Creation creation = plotQueryService
-                .findCreationByPlot(plotQueryService
-                .findByTitle(initPhotoRequest.title()).getId());
-
-        // creation 호출 후 , Photo 객체 생성후 저장하기
-        List<Photo> photoList = photoService
-                .savePhotos(creation,
-                        initPhotoRenderResponse,
-                        initPhotoRequest);
-
-        // response 생성하기
-        InitPhotoResultResponse initPhotoResultResponse = photoService.makeResult(photoList);
+            // 사진 생성 프롬프트로 사진 생성하기 ( gpt API )
+            InitPhotoRenderResponse initPhotoRenderResponse = creationService
+                    .initPhotoRender(InitPhotoRenderRequest
+                            .from(initPhotoResponse));
 
 
-        return initPhotoResultResponse;
+            // plot으로부터 creation 호출
+            Creation creation = plotQueryService
+                    .findCreationByPlot(plotQueryService
+                            .findByTitle(initPhotoRequest.title()).getId());
+
+            // creation 호출 후 , Photo 객체 생성후 저장하기
+            List<Photo> photoList = photoService
+                    .savePhotos(creation,
+                            initPhotoRenderResponse,
+                            initPhotoRequest);
+
+            // response 생성하기
+            return photoService.makeResult(photoList);
+
+        } finally {
+            photoGenerationMetrics.stop(sample);
+        }
+
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
@@ -27,11 +27,13 @@ import org.woojukang.remixlab.domain.plot.service.PlotService;
 import org.woojukang.remixlab.domain.quest.facade.QuestFacade;
 import org.woojukang.remixlab.domain.user.entity.User;
 import org.woojukang.remixlab.domain.video.entity.Video;
+import org.woojukang.remixlab.domain.video.facade.VideoPersistenceFacade;
 import org.woojukang.remixlab.domain.video.service.VideoService;
 import org.woojukang.remixlab.global.client.ai.dto.request.AiClientRequest;
 import org.woojukang.remixlab.global.client.ai.dto.request.prompt.template.InitPromptTemplate;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.metrics.PhotoGenerationMetrics;
+import org.woojukang.remixlab.global.metrics.VideoGenerationMetrics;
 import org.woojukang.remixlab.query.creation.dto.request.ShowPlotWithDetailRequest;
 import org.woojukang.remixlab.query.creation.dto.response.ShowMyCreationResponse;
 import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResponse;
@@ -60,20 +62,10 @@ public class CreationFacade {
     private final QuestFacade questFacade;
 
     private final PhotoGenerationMetrics photoGenerationMetrics;
+    private final VideoGenerationMetrics videoGenerationMetrics;
 
     private final CreationPersistenceFacade creationPersistenceFacade;
-
-    /*
-    WebFlux Block 메소드
-     */
-
-    @Transactional
-    public InitPlotResultResponse makePlot(String username,InitPlotRequest initPlotRequest){
-        return makePlotReactive(username,initPlotRequest)
-                .block();
-    }
-
-
+    private final VideoPersistenceFacade videoPersistenceFacade;
 
 
     /* plot 생성기
@@ -92,25 +84,16 @@ public class CreationFacade {
                                 .replace("{user_input}",
                                         initPlotRequest.user_input())));
 
-        // creation 생성 후 , 저장
-        Creation creation = creationService
-                .InitCreation(userQueryService
-                        .findByUsername(username),
-                        initPlotRequest);
-
         return creationService.initPlot(aiClientRequest)
-
-                .map(initPlotResponse -> {
-
-                    plotService.savePlot(creation, initPlotResponse);
-
-                    questFacade.onPlotCreated(username);
-
-                    return InitPlotResultResponse.from(
-                            creation.getId(),
-                            initPlotResponse
-                    );
-                });
+                .flatMap(initPlotResponse ->
+                        Mono.fromCallable(() ->
+                                creationPersistenceFacade.savePlotBlocking(
+                                        username,
+                                        initPlotRequest,
+                                        initPlotResponse
+                                )
+                        ).subscribeOn(Schedulers.boundedElastic())
+                );
     }
 
 
@@ -122,20 +105,48 @@ public class CreationFacade {
             DirectPhotoRequest directPhotoRequest,
             String username) {
 
+        // 플로우 구분 : direct
+        String flow = "direct";
+
+        // 현재 처리 중인 요청 수 증가
+        photoGenerationMetrics.incrementInflight(flow);
+
+        // 전체 요청의 end-to-end latency 측정 시작
+        Timer.Sample totalSample = photoGenerationMetrics.start();
+
         AiClientRequest aiClientRequest =
                 new AiClientRequest(directPhotoRequest.prompt());
 
+        // 텍스트 기반 사진 생성 기능의 호출 latency 측정 시작
+        Timer.Sample generationSample = photoGenerationMetrics.start();
+
+
         return creationService.makePhotoFromText(directPhotoRequest)
-                .flatMap(directPhotoResponse ->
-                        Mono.fromCallable(() ->
-                                        creationPersistenceFacade.saveDirectPhotoBlocking(
-                                                directPhotoResponse,
-                                                username,
-                                                aiClientRequest
-                                        )
-                                )
-                                .subscribeOn(Schedulers.boundedElastic())
-                );
+                // 텍스트 기반 사진 생성 성공 시 , generate 단계의 latency 기록
+                .doOnSuccess(res -> photoGenerationMetrics.stopStage(generationSample, flow, "generate"))
+                .flatMap(directPhotoResponse -> {
+                    Timer.Sample persistenceSample = photoGenerationMetrics.start();
+
+                    return Mono.fromCallable(() ->
+                                    creationPersistenceFacade.saveDirectPhotoBlocking(
+                                            directPhotoResponse,
+                                            username,
+                                            aiClientRequest
+                                    )
+                            )
+                            // blocking 작업에 대해서는 boundedElastic 스레드풀로 분리
+                            .subscribeOn(Schedulers.boundedElastic())
+                            // 저장 성공 시 , persistence 단계 latency 기록
+                            .doOnSuccess(res -> photoGenerationMetrics.stopStage(persistenceSample, flow, "persistence"));
+                })
+                // 전체 요청 성공 건수 증가
+                .doOnSuccess(result -> photoGenerationMetrics.incrementRequest(flow, "success"))
+                // 전체 요청 실패 건수 증가
+                .doOnError(e -> photoGenerationMetrics.incrementRequest(flow, "fail"))
+                .doFinally(signal -> {
+                    photoGenerationMetrics.stopTotal(totalSample, flow); // 전체 end-to-end latency 기록
+                    photoGenerationMetrics.decrementInflight(flow); // 현재 처리 중 요청 수 감소
+                });
     }
 
 
@@ -146,38 +157,63 @@ public class CreationFacade {
             InitPhotoRequest initPhotoRequest,
             String username) {
 
-        Timer.Sample sample = photoGenerationMetrics.start();
+        // 플로우 구분 : plot
+        String flow = "plot";
+
+        // 현재 처리 중인 요청 수 증가
+        photoGenerationMetrics.incrementInflight(flow);
+
+        // 전체 요청의 end-to-end latency 측정 시작
+        Timer.Sample totalSample = photoGenerationMetrics.start();
 
         AiClientRequest aiClientRequest =
                 new AiClientRequest(
-                        String.format(
-                                InitPromptTemplate.INIT_IMAGE_PROMPT_MAKING
-                                        .getTemplate()
-                                        .replace(
-                                                "{user_input}",
-                                                creationService.requestToString(initPhotoRequest)
-                                        )
-                        )
+                        InitPromptTemplate.INIT_IMAGE_PROMPT_MAKING
+                                .getTemplate()
+                                .replace("{user_input}",
+                                        creationService.requestToString(initPhotoRequest))
                 );
 
+        // 이미지 생성용 데이터렌더링 로직 latency 측정 시작
+        Timer.Sample initSample = photoGenerationMetrics.start();
+
+
         return creationService.initPhotos(aiClientRequest)
-                .flatMap(initPhotoResponse ->
-                        creationService.initPhotoRender(
-                                InitPhotoRenderRequest.from(initPhotoResponse)
-                        )
-                )
-                .flatMap(initPhotoRenderResponse ->
-                        Mono.fromCallable(() ->
-                                        creationPersistenceFacade.saveInitPhotosBlocking(
-                                                initPhotoRenderResponse,
-                                                initPhotoRequest
-                                        )
-                                )
-                                .subscribeOn(Schedulers.boundedElastic())
-                )
-                .doOnSuccess(result -> photoGenerationMetrics.success())
-                .doOnError(e -> photoGenerationMetrics.fail())
-                .doFinally(signal -> photoGenerationMetrics.stop(sample));
+                // 렌더링 단계 latency 기록
+                .doOnSuccess(res -> photoGenerationMetrics.stopStage(initSample, flow, "init"))
+                .flatMap(initPhotoResponse -> {
+                    // 이미지로 변환 하는 로직 latency 측정 시작
+                    Timer.Sample renderSample = photoGenerationMetrics.start();
+
+                    return creationService.initPhotoRender(
+                                    InitPhotoRenderRequest.from(initPhotoResponse)
+                            )
+                            // 랜더링 성공 시 latency 기록
+                            .doOnSuccess(res -> photoGenerationMetrics.stopStage(renderSample, flow, "render"));
+                })
+                .flatMap(initPhotoRenderResponse -> {
+                    // persistence 단계 latency 측정 시작
+                    Timer.Sample persistenceSample = photoGenerationMetrics.start();
+
+                    return Mono.fromCallable(() ->
+                                    creationPersistenceFacade.saveInitPhotosBlocking(
+                                            initPhotoRenderResponse,
+                                            initPhotoRequest
+                                    )
+                            )
+                            // JPA 로직은 boundedElastic 스레드 내부에서 처리
+                            .subscribeOn(Schedulers.boundedElastic())
+                            // JPA 로직 성공 시 , persistence 단계 latency 기록
+                            .doOnSuccess(res -> photoGenerationMetrics.stopStage(persistenceSample, flow, "persistence"));
+                })
+                // 전체 성공 건수 증가
+                .doOnSuccess(result -> photoGenerationMetrics.incrementRequest(flow, "success"))
+                .doOnError(e -> photoGenerationMetrics.incrementRequest(flow, "fail"))
+                // 마지막에 항상 전체 latency 기록 및 in-flight 감소
+                .doFinally(signal -> {
+                    photoGenerationMetrics.stopTotal(totalSample, flow);
+                    photoGenerationMetrics.decrementInflight(flow);
+                });
     }
 
 
@@ -185,63 +221,71 @@ public class CreationFacade {
     Video 생성하기
      */
 
-    @Transactional
-    public InitVideoResponse makeVideoByPhotos(InitVideoRequest initVideoRequest,String username){
 
-        // Creation 가져오기
-        Creation creation = creationQueryService
-                .findCreationEntityById(initVideoRequest
-                        .creationId());
+    public Mono<InitVideoResponse> makeVideoByPhotosReactive(
+            InitVideoRequest initVideoRequest,
+            String username) {
+        String flow = "photo_based";
 
-        // plot 정보 가져오기
-        ShowPlotWithDetailResponse showPlotWithDetailResponse =
-                plotQueryService
-                        .findPlotWithDetailsByCreationId(new ShowPlotWithDetailRequest(initVideoRequest
-                                .creationId()));
+        videoGenerationMetrics.incrementInflight(flow);
+        Timer.Sample totalSample = videoGenerationMetrics.start();
 
+        Timer.Sample querySample = videoGenerationMetrics.start();
 
-        // 사진+플롯 정보를 프롬프트로 만든 후 , Video 생성하기
-        SoraResponse soraResponse = creationService
-                .makeVideoByPhotos(showPlotWithDetailResponse);
+        return Mono.fromCallable(() ->
+                        videoPersistenceFacade.findPlotDetailsBlocking(initVideoRequest.creationId())
+                )
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnSuccess(res -> videoGenerationMetrics.stopStage(querySample, flow, "query_plot"))
 
-        // Video 객체 생성후 저장하기
-        Video video = videoService.saveVideo(creation,soraResponse);
+                .flatMap(showPlotWithDetailResponse -> {
+                    Timer.Sample soraSample = videoGenerationMetrics.start();
 
-        // 퀘스트 체크
-        questFacade.onVideoCreated(username);
+                    return creationService.makeVideoByPhotosReactive(showPlotWithDetailResponse)
+                            .doOnSuccess(res -> videoGenerationMetrics.stopStage(soraSample, flow, "generate_video"));
+                })
 
-        return new InitVideoResponse(video.getId(),
-                soraResponse
-                .id(),
-                "비디오 생성이 접수되었습니다.");
+                .flatMap(soraResponse -> {
+                    Timer.Sample persistenceSample = videoGenerationMetrics.start();
 
+                    return Mono.fromCallable(() ->
+                                    videoPersistenceFacade.saveVideoByPhotosBlocking(
+                                            initVideoRequest,
+                                            username,
+                                            soraResponse
+                                    )
+                            )
+                            .subscribeOn(Schedulers.boundedElastic())
+                            .doOnSuccess(res -> videoGenerationMetrics.stopStage(
+                                    persistenceSample,
+                                    flow,
+                                    "persistence"
+                            ));
+                })
+
+                .doOnSuccess(result -> videoGenerationMetrics.incrementRequest(flow, "success"))
+                .doOnError(e -> videoGenerationMetrics.incrementRequest(flow, "fail"))
+                .doFinally(signal -> {
+                    videoGenerationMetrics.stopTotal(totalSample, flow);
+                    videoGenerationMetrics.decrementInflight(flow);
+                });
     }
 
-    @Transactional
-    public InitVideoResponse makeVideoByText(String username,DirectVideoRequest directVideoRequest){
+    public Mono<InitVideoResponse> makeVideoByTextReactive(
+            String username,
+            DirectVideoRequest directVideoRequest) {
 
-        User user = userQueryService.findByUsername(username);
-
-        SoraResponse soraResponse =  creationService
-                .makeVideoByText(directVideoRequest);
-
-        AiClientRequest aiClientRequest = new AiClientRequest(directVideoRequest.prompt());
-
-        // Creation 생성하기
-        Creation creation = creationService
-                .makeCreationDirect(user,aiClientRequest);
-
-        // Video 객체 생성하기
-        Video video = videoService.saveVideo(creation,soraResponse);
-
-        // 퀘스트 체크
-        questFacade.onVideoCreated(username);
-
-        return new InitVideoResponse(video.getId(),
-                soraResponse
-                .id(),
-                "비디오 생성이 접수되었습니다.");
-
+        return creationService.makeVideoByTextReactive(directVideoRequest)
+                .flatMap(soraResponse ->
+                        Mono.fromCallable(() ->
+                                videoPersistenceFacade.saveVideoByTextBlocking(
+                                        username,
+                                        directVideoRequest,
+                                        new AiClientRequest(directVideoRequest.prompt()),
+                                        soraResponse
+                                )
+                        ).subscribeOn(Schedulers.boundedElastic())
+                );
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationFacade.java
@@ -39,6 +39,7 @@ import org.woojukang.remixlab.query.creation.service.CreationQueryService;
 import org.woojukang.remixlab.query.creation.service.PlotQueryService;
 import org.woojukang.remixlab.query.user.service.UserQueryService;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.List;
 
@@ -59,6 +60,8 @@ public class CreationFacade {
     private final QuestFacade questFacade;
 
     private final PhotoGenerationMetrics photoGenerationMetrics;
+
+    private final CreationPersistenceFacade creationPersistenceFacade;
 
     /*
     WebFlux Block 메소드
@@ -117,36 +120,28 @@ public class CreationFacade {
     // Text 기반 사진 생성
     public Mono<DirectPhotoResultResponse> makePhotoDirectlyReactive(
             DirectPhotoRequest directPhotoRequest,
-            String username){
+            String username) {
 
         AiClientRequest aiClientRequest =
                 new AiClientRequest(directPhotoRequest.prompt());
 
         return creationService.makePhotoFromText(directPhotoRequest)
-
-                .map(directPhotoResponse -> {
-
-                    User user = userQueryService
-                            .findByUsername(username);
-
-                    Creation creation = creationService
-                            .makeCreationDirect(user, aiClientRequest);
-
-                    DirectPhotoResultResponse result =
-                            photoService.saveDirectPhoto(
-                                    creation,
-                                    directPhotoResponse
-                            );
-
-                    questFacade.onPhotoCreated(username);
-
-                    return result;
-                });
+                .flatMap(directPhotoResponse ->
+                        Mono.fromCallable(() ->
+                                        creationPersistenceFacade.saveDirectPhotoBlocking(
+                                                directPhotoResponse,
+                                                username,
+                                                aiClientRequest
+                                        )
+                                )
+                                .subscribeOn(Schedulers.boundedElastic())
+                );
     }
 
 
+
+
     // Plot 기반 사진 생성
-    @Transactional
     public Mono<InitPhotoResultResponse> makePhotosReactive(
             InitPhotoRequest initPhotoRequest,
             String username) {
@@ -154,13 +149,16 @@ public class CreationFacade {
         Timer.Sample sample = photoGenerationMetrics.start();
 
         AiClientRequest aiClientRequest =
-                new AiClientRequest(String.format(
-                        InitPromptTemplate
-                                .INIT_IMAGE_PROMPT_MAKING
-                                .getTemplate()
-                                .replace("{user_input}",
-                                        creationService.requestToString(initPhotoRequest))
-                ));
+                new AiClientRequest(
+                        String.format(
+                                InitPromptTemplate.INIT_IMAGE_PROMPT_MAKING
+                                        .getTemplate()
+                                        .replace(
+                                                "{user_input}",
+                                                creationService.requestToString(initPhotoRequest)
+                                        )
+                        )
+                );
 
         return creationService.initPhotos(aiClientRequest)
                 .flatMap(initPhotoResponse ->
@@ -168,25 +166,17 @@ public class CreationFacade {
                                 InitPhotoRenderRequest.from(initPhotoResponse)
                         )
                 )
-                .map(initPhotoRenderResponse -> {
-
-                    Creation creation = plotQueryService
-                            .findCreationByPlot(
-                                    plotQueryService
-                                            .findByTitle(initPhotoRequest.title())
-                                            .getId()
-                            );
-
-                    List<Photo> photoList = photoService
-                            .savePhotos(creation,
-                                    initPhotoRenderResponse,
-                                    initPhotoRequest);
-
-                    photoGenerationMetrics.success(); // throughput 증가
-
-                    return photoService.makeResult(photoList);
-                })
-                .doOnError(e -> photoGenerationMetrics.fail()) //  실패 throughput
+                .flatMap(initPhotoRenderResponse ->
+                        Mono.fromCallable(() ->
+                                        creationPersistenceFacade.saveInitPhotosBlocking(
+                                                initPhotoRenderResponse,
+                                                initPhotoRequest
+                                        )
+                                )
+                                .subscribeOn(Schedulers.boundedElastic())
+                )
+                .doOnSuccess(result -> photoGenerationMetrics.success())
+                .doOnError(e -> photoGenerationMetrics.fail())
                 .doFinally(signal -> photoGenerationMetrics.stop(sample));
     }
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationPersistenceFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationPersistenceFacade.java
@@ -1,0 +1,78 @@
+package org.woojukang.remixlab.domain.creation.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.woojukang.remixlab.domain.creation.dto.request.pipeline.InitPhotoRequest;
+import org.woojukang.remixlab.domain.creation.dto.response.direct.DirectPhotoResponse;
+import org.woojukang.remixlab.domain.creation.dto.response.photo.DirectPhotoResultResponse;
+import org.woojukang.remixlab.domain.creation.dto.response.photo.InitPhotoResultResponse;
+import org.woojukang.remixlab.domain.creation.dto.response.pipeline.InitPhotoRenderResponse;
+import org.woojukang.remixlab.domain.creation.entity.Creation;
+import org.woojukang.remixlab.domain.creation.service.CreationService;
+import org.woojukang.remixlab.domain.photo.entity.Photo;
+import org.woojukang.remixlab.domain.photo.service.PhotoService;
+import org.woojukang.remixlab.domain.quest.facade.QuestFacade;
+import org.woojukang.remixlab.domain.user.entity.User;
+import org.woojukang.remixlab.global.client.ai.dto.request.AiClientRequest;
+import org.woojukang.remixlab.query.creation.service.PlotQueryService;
+import org.woojukang.remixlab.query.user.service.UserQueryService;
+
+import java.util.List;
+
+/*
+JPA Blocking 메소드를 따로 보관하는 파사드
+ */
+@Component
+@RequiredArgsConstructor
+public class CreationPersistenceFacade {
+
+    private final PlotQueryService plotQueryService;
+    private final UserQueryService userQueryService;
+
+    private final CreationService creationService;
+    private final PhotoService photoService;
+
+    private final QuestFacade questFacade;
+
+
+
+    @Transactional
+    public InitPhotoResultResponse saveInitPhotosBlocking(
+            InitPhotoRenderResponse initPhotoRenderResponse,
+            InitPhotoRequest initPhotoRequest) {
+
+        Creation creation = plotQueryService
+                .findCreationByPlot(
+                        plotQueryService
+                                .findByTitle(initPhotoRequest.title())
+                                .getId()
+                );
+
+        List<Photo> photoList = photoService.savePhotos(
+                creation,
+                initPhotoRenderResponse,
+                initPhotoRequest
+        );
+
+        return photoService.makeResult(photoList);
+    }
+
+    @Transactional
+    protected DirectPhotoResultResponse saveDirectPhotoBlocking(
+            DirectPhotoResponse directPhotoResponse,
+            String username,
+            AiClientRequest aiClientRequest) {
+
+        User user = userQueryService.findByUsername(username);
+
+        Creation creation = creationService.makeCreationDirect(user, aiClientRequest);
+
+        DirectPhotoResultResponse result =
+                photoService.saveDirectPhoto(creation, directPhotoResponse);
+
+        questFacade.onPhotoCreated(username);
+
+        return result;
+    }
+}

--- a/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationPersistenceFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/facade/CreationPersistenceFacade.java
@@ -4,14 +4,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.woojukang.remixlab.domain.creation.dto.request.pipeline.InitPhotoRequest;
+import org.woojukang.remixlab.domain.creation.dto.request.pipeline.InitPlotRequest;
 import org.woojukang.remixlab.domain.creation.dto.response.direct.DirectPhotoResponse;
 import org.woojukang.remixlab.domain.creation.dto.response.photo.DirectPhotoResultResponse;
 import org.woojukang.remixlab.domain.creation.dto.response.photo.InitPhotoResultResponse;
 import org.woojukang.remixlab.domain.creation.dto.response.pipeline.InitPhotoRenderResponse;
+import org.woojukang.remixlab.domain.creation.dto.response.pipeline.InitPlotResponse;
+import org.woojukang.remixlab.domain.creation.dto.response.plot.InitPlotResultResponse;
 import org.woojukang.remixlab.domain.creation.entity.Creation;
 import org.woojukang.remixlab.domain.creation.service.CreationService;
 import org.woojukang.remixlab.domain.photo.entity.Photo;
 import org.woojukang.remixlab.domain.photo.service.PhotoService;
+import org.woojukang.remixlab.domain.plot.service.PlotService;
 import org.woojukang.remixlab.domain.quest.facade.QuestFacade;
 import org.woojukang.remixlab.domain.user.entity.User;
 import org.woojukang.remixlab.global.client.ai.dto.request.AiClientRequest;
@@ -32,8 +36,27 @@ public class CreationPersistenceFacade {
 
     private final CreationService creationService;
     private final PhotoService photoService;
+    private final PlotService plotService;
 
     private final QuestFacade questFacade;
+
+    @Transactional
+
+    public InitPlotResultResponse savePlotBlocking(
+            String username,
+            InitPlotRequest initPlotRequest,
+            InitPlotResponse initPlotResponse) {
+
+        User user = userQueryService.findByUsername(username);
+        Creation creation = creationService.InitCreation(user, initPlotRequest);
+        plotService.savePlot(creation, initPlotResponse);
+        questFacade.onPlotCreated(username);
+
+        return InitPlotResultResponse.from(
+                creation.getId(),
+                initPlotResponse
+        );
+    }
 
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/service/CreationService.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/service/CreationService.java
@@ -23,6 +23,7 @@ import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.utils.ai.AiUtils;
 import org.woojukang.remixlab.global.utils.creation.CreationUtils;
 import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResponse;
+import reactor.core.publisher.Mono;
 
 @Service
 @RequiredArgsConstructor
@@ -80,14 +81,11 @@ public class CreationService {
 
 
 
-    public InitPlotResponse initPlot(AiClientRequest aiClientRequest){
-        // Gpt API 호출
-       return aiUtils
-               .responseParsing(aiUtils
-                                .getJsonText(plotModel,
-                                        aiClientRequest),
-                        InitPlotResponse.class);
+    public Mono<InitPlotResponse> initPlot(AiClientRequest aiClientRequest){
 
+        return aiUtils
+                .getJsonText(plotModel, aiClientRequest)
+                .map(json -> aiUtils.responseParsing(json, InitPlotResponse.class));
     }
 
 
@@ -96,28 +94,24 @@ public class CreationService {
      */
 
     // 사진 렌더링에 맞는 형태로 변환하기
-    public InitPhotoResponse initPhotos
-    (AiClientRequest aiClientRequest){
+    public Mono<InitPhotoResponse> initPhotos(AiClientRequest aiClientRequest){
 
         return aiUtils
-                .responseParsing(aiUtils
-                                .getJsonText(plotModel,
-                                        aiClientRequest),
-                        InitPhotoResponse.class);
-
+                .getJsonText(plotModel, aiClientRequest)
+                .map(json -> aiUtils.responseParsing(json, InitPhotoResponse.class));
     }
 
     // 가공 프롬프트 -> 사진 생성하기
-    public InitPhotoRenderResponse initPhotoRender
-            (InitPhotoRenderRequest request){
-        return aiUtils
-                .makePhotos(request)
-                .join();
+    public Mono<InitPhotoRenderResponse> initPhotoRender(
+            InitPhotoRenderRequest request){
+
+        return aiUtils.makePhotos(request);
     }
 
-    public DirectPhotoResponse makePhotoFromText(DirectPhotoRequest directPhotoRequest){
-        return aiUtils
-                .makePhotoFromText(directPhotoRequest);
+    public Mono<DirectPhotoResponse> makePhotoFromText(
+            DirectPhotoRequest directPhotoRequest){
+
+        return aiUtils.makePhotoFromText(directPhotoRequest);
     }
 
 
@@ -127,15 +121,15 @@ public class CreationService {
 
     public SoraResponse makeVideoByPhotos(ShowPlotWithDetailResponse showPlotWithDetailResponse){
         return aiUtils
-                .makeVideoFromPhotos(showPlotWithDetailResponse);
+                .makeVideoFromPhotos(showPlotWithDetailResponse)
+                .block();
     }
 
     public SoraResponse makeVideoByText(DirectVideoRequest directVideoRequest){
         return aiUtils
-                .makeVideoByText(directVideoRequest);
+                .makeVideoByText(directVideoRequest)
+                .block();
     }
-
-
 
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/creation/service/CreationService.java
+++ b/src/main/java/org/woojukang/remixlab/domain/creation/service/CreationService.java
@@ -119,16 +119,13 @@ public class CreationService {
     VIDEO 생성 메소드
      */
 
-    public SoraResponse makeVideoByPhotos(ShowPlotWithDetailResponse showPlotWithDetailResponse){
-        return aiUtils
-                .makeVideoFromPhotos(showPlotWithDetailResponse)
-                .block();
+    public Mono<SoraResponse> makeVideoByPhotosReactive(ShowPlotWithDetailResponse showPlotWithDetailResponse){
+        return aiUtils.makeVideoFromPhotos(showPlotWithDetailResponse);
     }
 
-    public SoraResponse makeVideoByText(DirectVideoRequest directVideoRequest){
+    public Mono<SoraResponse> makeVideoByTextReactive(DirectVideoRequest directVideoRequest){
         return aiUtils
-                .makeVideoByText(directVideoRequest)
-                .block();
+                .makeVideoByText(directVideoRequest);
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/domain/video/facade/VideoFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/video/facade/VideoFacade.java
@@ -10,6 +10,8 @@ import org.woojukang.remixlab.domain.video.entity.Video;
 import org.woojukang.remixlab.domain.video.entity.VideoStatus;
 import org.woojukang.remixlab.domain.video.service.VideoService;
 import org.woojukang.remixlab.query.creation.service.VideoQueryService;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.util.Objects;
 
@@ -36,20 +38,31 @@ public class VideoFacade {
     public ShowVideoResponse getShowVideo
             (ShowVideoRequest showVideoRequest){
 
+        return getShowVideoReactive(showVideoRequest)
+                .block();
+
+    }
+
+    @Transactional
+    public Mono<ShowVideoResponse> getShowVideoReactive(
+            ShowVideoRequest showVideoRequest){
+
         Video video = videoQueryService
-                .findByCreationId(showVideoRequest
-                        .creationId());
+                .findByCreationId(showVideoRequest.creationId());
 
-        // 요청해서 byte 코드로 가져오기 -> stream 변환후 GCS 저장 , URL 반환
-        String url = videoService
-                .uploadVideo(videoService.
-                        getVideoUrl(video
-                                .getSoraVideoId()));
+        return videoService
+                .getVideoUrl(video.getSoraVideoId())
+                .as(videoService::uploadVideo)
+                .flatMap(url ->
+                        Mono.fromCallable(() -> {
 
-        video.updateUrl(url);
-        videoService.saveVideo(video);
+                            video.updateUrl(url);
+                            videoService.saveVideo(video);
 
-        return new ShowVideoResponse(url);
+                            return url;
 
+                        }).subscribeOn(Schedulers.boundedElastic()) // blocking 메소드는 boundedElastic()처리
+                )
+                .map(ShowVideoResponse::new);
     }
 }

--- a/src/main/java/org/woojukang/remixlab/domain/video/facade/VideoPersistenceFacade.java
+++ b/src/main/java/org/woojukang/remixlab/domain/video/facade/VideoPersistenceFacade.java
@@ -1,0 +1,82 @@
+package org.woojukang.remixlab.domain.video.facade;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.woojukang.remixlab.domain.creation.dto.request.direct.DirectVideoRequest;
+import org.woojukang.remixlab.domain.creation.dto.request.pipeline.InitVideoRequest;
+import org.woojukang.remixlab.domain.creation.dto.response.pipeline.InitVideoResponse;
+import org.woojukang.remixlab.domain.creation.entity.Creation;
+import org.woojukang.remixlab.domain.creation.service.CreationService;
+import org.woojukang.remixlab.domain.quest.facade.QuestFacade;
+import org.woojukang.remixlab.domain.user.entity.User;
+import org.woojukang.remixlab.domain.video.entity.Video;
+import org.woojukang.remixlab.domain.video.service.VideoService;
+import org.woojukang.remixlab.global.client.ai.dto.request.AiClientRequest;
+import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
+import org.woojukang.remixlab.query.creation.dto.request.ShowPlotWithDetailRequest;
+import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResponse;
+import org.woojukang.remixlab.query.creation.service.CreationQueryService;
+import org.woojukang.remixlab.query.creation.service.PlotQueryService;
+import org.woojukang.remixlab.query.user.service.UserQueryService;
+
+@Component
+@RequiredArgsConstructor
+public class VideoPersistenceFacade {
+
+    private final CreationQueryService creationQueryService;
+    private final PlotQueryService plotQueryService;
+    private final UserQueryService userQueryService;
+    private final CreationService creationService;
+    private final VideoService videoService;
+    private final QuestFacade questFacade;
+
+    @Transactional
+    public InitVideoResponse saveVideoByPhotosBlocking(
+            InitVideoRequest initVideoRequest,
+            String username,
+            SoraResponse soraResponse
+    ) {
+        Creation creation = creationQueryService
+                .findCreationEntityById(initVideoRequest.creationId());
+
+        Video video = videoService.saveVideo(creation, soraResponse);
+
+        questFacade.onVideoCreated(username);
+
+        return new InitVideoResponse(
+                video.getId(),
+                soraResponse.id(),
+                "비디오 생성이 접수되었습니다."
+        );
+    }
+
+    @Transactional
+    public InitVideoResponse saveVideoByTextBlocking(
+            String username,
+            DirectVideoRequest directVideoRequest,
+            AiClientRequest aiClientRequest,
+            SoraResponse soraResponse
+    ) {
+        User user = userQueryService.findByUsername(username);
+
+        Creation creation = creationService.makeCreationDirect(user, aiClientRequest);
+
+        Video video = videoService.saveVideo(creation, soraResponse);
+
+        questFacade.onVideoCreated(username);
+
+        return new InitVideoResponse(
+                video.getId(),
+                soraResponse.id(),
+                "비디오 생성이 접수되었습니다."
+        );
+    }
+
+
+    public ShowPlotWithDetailResponse findPlotDetailsBlocking(Long creationId) {
+        return plotQueryService.findPlotWithDetailsByCreationId(
+                new ShowPlotWithDetailRequest(creationId)
+        );
+    }
+}

--- a/src/main/java/org/woojukang/remixlab/domain/video/service/VideoService.java
+++ b/src/main/java/org/woojukang/remixlab/domain/video/service/VideoService.java
@@ -1,6 +1,8 @@
 package org.woojukang.remixlab.domain.video.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.stereotype.Service;
 import org.woojukang.remixlab.domain.creation.entity.Creation;
 import org.woojukang.remixlab.domain.video.entity.Video;
@@ -9,6 +11,9 @@ import org.woojukang.remixlab.domain.video.repository.VideoRepository;
 import org.woojukang.remixlab.global.client.ai.GptClient;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.infra.GcsStorageUploader;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.ByteArrayInputStream;
 
@@ -37,16 +42,30 @@ public class VideoService {
         return video;
     }
 
-    public byte[] getVideoUrl(String videoId) {
+    public Flux<DataBuffer> getVideoUrl(String videoId) {
 
-        return gptClient.getVideo(videoId);
+        return gptClient.getVideoStream(videoId);
 
     }
 
-    public String uploadVideo(byte[] bytes) {
+    // GCP Storage에 비디오 저장하기
+    public Mono<String> uploadVideo(Flux<DataBuffer> videoStream){
 
-        return gcsStorageUploader
-                .videoUpload(new ByteArrayInputStream(bytes));
+        return DataBufferUtils.join(videoStream)
+                .flatMap(buffer ->
+                        Mono.fromCallable(() -> {
+
+                            byte[] bytes = new byte[buffer.readableByteCount()];
+                            buffer.read(bytes);
+
+                            DataBufferUtils.release(buffer);
+
+                            return gcsStorageUploader.videoUpload(
+                                    new ByteArrayInputStream(bytes)
+                            );
+
+                        }).subscribeOn(Schedulers.boundedElastic())
+                );
     }
 
     public void saveVideo(Video video) {

--- a/src/main/java/org/woojukang/remixlab/domain/video/worker/VideoWorker.java
+++ b/src/main/java/org/woojukang/remixlab/domain/video/worker/VideoWorker.java
@@ -30,7 +30,10 @@ public class VideoWorker {
         ).forEach(video -> {
             try {
                 SoraStatusResponse res =
-                        gptClient.getVideoStatus(video.getSoraVideoId());
+                        gptClient
+                                .getVideoStatus(video.getSoraVideoId())
+                                .block(); // Reactive 종료
+
                 updateVideoStatus(video, res);
             } catch (Exception e) {
                 log.error("Video status polling failed. videoId={}", video.getId(), e);

--- a/src/main/java/org/woojukang/remixlab/global/client/ai/GptClient.java
+++ b/src/main/java/org/woojukang/remixlab/global/client/ai/GptClient.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 import org.woojukang.remixlab.global.client.ai.dto.request.photo.DALLERequest;
 import org.woojukang.remixlab.global.client.ai.dto.request.plot.GptRequest;
 import org.woojukang.remixlab.global.client.ai.dto.request.video.SoraRequest;
@@ -13,12 +14,13 @@ import org.woojukang.remixlab.global.client.ai.dto.response.photo.DALLEResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.plot.GptResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraStatusResponse;
+import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
 public class GptClient implements AiClient {
 
-    private final RestTemplate openAIRestTemplate;
+    private final WebClient openAIWebClient;
 
     @Value("${openai.url.gpt}")
     private String gptUrl;
@@ -36,51 +38,51 @@ public class GptClient implements AiClient {
     private String soraDownloadUrl;
 
     // 프롬프트 -> 텍스트
-    public GptResponse sendMessage
-    (GptRequest request) {
+    public Mono<GptResponse> sendMessage(GptRequest request) {
 
-        return openAIRestTemplate
-                .postForObject(gptUrl,
-                        request,
-                        GptResponse.class);
+        return openAIWebClient.post()
+                .uri(gptUrl)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(GptResponse.class);
     }
 
     // 프롬프트 -> 사진
-    public DALLEResponse makeImage
-    (DALLERequest request){
+    public Mono<DALLEResponse> makeImage(DALLERequest request){
 
-        return openAIRestTemplate
-                .postForObject(dallEUrl,
-                        request,
-                        DALLEResponse.class);
+        return openAIWebClient.post()
+                .uri(dallEUrl)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(DALLEResponse.class);
     }
 
 
-    public SoraResponse makeVideo
-            (SoraRequest request){
-        return openAIRestTemplate
-                .postForObject(soraUrl,
-                        request,
-                        SoraResponse.class);
+    public Mono<SoraResponse> makeVideo(SoraRequest request){
+
+        return openAIWebClient.post()
+                .uri(soraUrl)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(SoraResponse.class);
     }
 
-    public SoraStatusResponse getVideoStatus
-            (String videoId){
+    public Mono<SoraStatusResponse> getVideoStatus(String videoId){
 
-        return openAIRestTemplate
-                .getForObject(soraStatusUrl,
-                        SoraStatusResponse.class,
-                        videoId);
-
+        return openAIWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(soraStatusUrl)
+                        .build(videoId))
+                .retrieve()
+                .bodyToMono(SoraStatusResponse.class);
     }
 
-    public byte[] getVideo(String videoId){
+    public Mono<byte[]> getVideo(String videoId){
 
-       return openAIRestTemplate.getForObject(
-               soraDownloadUrl + videoId + "/content",
-               byte[].class
-       );
-
+        return openAIWebClient.get()
+                .uri(soraDownloadUrl + videoId + "/content")
+                .retrieve()
+                .bodyToMono(byte[].class);
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/global/client/ai/GptClient.java
+++ b/src/main/java/org/woojukang/remixlab/global/client/ai/GptClient.java
@@ -2,6 +2,7 @@ package org.woojukang.remixlab.global.client.ai;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,7 @@ import org.woojukang.remixlab.global.client.ai.dto.response.photo.DALLEResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.plot.GptResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraStatusResponse;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
@@ -77,12 +79,12 @@ public class GptClient implements AiClient {
                 .bodyToMono(SoraStatusResponse.class);
     }
 
-    public Mono<byte[]> getVideo(String videoId){
+    public Flux<DataBuffer> getVideoStream(String videoId){
 
         return openAIWebClient.get()
                 .uri(soraDownloadUrl + videoId + "/content")
                 .retrieve()
-                .bodyToMono(byte[].class);
+                .bodyToFlux(DataBuffer.class);
     }
 
 

--- a/src/main/java/org/woojukang/remixlab/global/config/ai/GptConfig.java
+++ b/src/main/java/org/woojukang/remixlab/global/config/ai/GptConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class GptConfig {
@@ -11,18 +12,11 @@ public class GptConfig {
     @Value("${openai.api.key}")
     private String apiKey;
 
-    @Bean("openAIRestTemplate")
-    public RestTemplate openAIRestTemplate(){
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.getInterceptors()
-                .add(((request, body, execution) -> {
-                            request.getHeaders().add("Authorization", "Bearer " + apiKey);
-                            return execution.execute(request,body);
-                        })
-                );
-        return restTemplate;
-
+    @Bean("openAIWebClient")
+    public WebClient openAIWebClient() {
+        return WebClient.builder()
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .build();
     }
-
 
 }

--- a/src/main/java/org/woojukang/remixlab/global/config/ai/GptConfig.java
+++ b/src/main/java/org/woojukang/remixlab/global/config/ai/GptConfig.java
@@ -16,6 +16,10 @@ public class GptConfig {
     public WebClient openAIWebClient() {
         return WebClient.builder()
                 .defaultHeader("Authorization", "Bearer " + apiKey)
+                .codecs(configurer ->
+                        configurer.defaultCodecs()
+                                .maxInMemorySize(10 * 1024 * 1024) // 10MB
+                )
                 .build();
     }
 

--- a/src/main/java/org/woojukang/remixlab/global/config/metrics/MetricsConfig.java
+++ b/src/main/java/org/woojukang/remixlab/global/config/metrics/MetricsConfig.java
@@ -1,0 +1,18 @@
+package org.woojukang.remixlab.global.config.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> commonTags() {
+        return registry -> registry.config()
+                .commonTags(
+                        "app", "remixlab"
+                );
+    }
+}

--- a/src/main/java/org/woojukang/remixlab/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/woojukang/remixlab/global/config/security/SecurityConfig.java
@@ -130,6 +130,7 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
+                        .requestMatchers("/actuator/**","/actuator/prometheus").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/org/woojukang/remixlab/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/woojukang/remixlab/global/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.woojukang.remixlab.global.config.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -72,7 +73,33 @@ public class SecurityConfig {
         return authenticationConfiguration.getAuthenticationManager();
     }
 
+    // API 문서 및 옵저버 툴 관련 설정
     @Bean
+    @Order(1)
+    public SecurityFilterChain apiSecurityFilterChain(HttpSecurity httpSecurity)
+            throws Exception {
+
+        httpSecurity
+                .securityMatcher(
+                        "/actuator/**",
+                        "/swagger-ui/**",
+                        "/swagger-ui.html",
+                        "/v3/api-docs/**",
+                        "/v3/api-docs",
+                        "/swagger-resources/**",
+                        "/webjars/**",
+                        "/mock/api/**"
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .csrf(AbstractHttpConfigurer::disable);
+
+        return httpSecurity.build();
+    }
+
+    @Bean
+    @Order(2)
     public SecurityFilterChain securityfilterChain(HttpSecurity httpSecurity,
                                                    LoginFilter loginFilter)
             throws Exception {
@@ -121,16 +148,6 @@ public class SecurityConfig {
         httpSecurity
                 .authorizeHttpRequests((auth)->auth
                         .requestMatchers("/login","/api/v1/user/create").permitAll()
-                        .requestMatchers("/refresh").permitAll()
-                        .requestMatchers(
-                                "/swagger-ui/**",
-                                "/swagger-ui.html",
-                                "/v3/api-docs/**",
-                                "/v3/api-docs",
-                                "/swagger-resources/**",
-                                "/webjars/**"
-                        ).permitAll()
-                        .requestMatchers("/actuator/**","/actuator/prometheus").permitAll()
                         .anyRequest().authenticated()
                 );
 

--- a/src/main/java/org/woojukang/remixlab/global/metrics/AIMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/AIMetrics.java
@@ -6,5 +6,13 @@ public interface AIMetrics {
 
     Timer.Sample start();
 
-    void stop(Timer.Sample sample);
+    void stopTotal(Timer.Sample sample, String flow);
+
+    void stopStage(Timer.Sample sample, String flow, String stage);
+
+    void incrementRequest(String flow, String result);
+
+    void incrementInflight(String flow);
+
+    void decrementInflight(String flow);
 }

--- a/src/main/java/org/woojukang/remixlab/global/metrics/AIMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/AIMetrics.java
@@ -1,0 +1,10 @@
+package org.woojukang.remixlab.global.metrics;
+
+import io.micrometer.core.instrument.Timer;
+
+public interface AIMetrics {
+
+    Timer.Sample start();
+
+    void stop(Timer.Sample sample);
+}

--- a/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
@@ -1,7 +1,9 @@
 package org.woojukang.remixlab.global.metrics;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +12,19 @@ import org.springframework.stereotype.Component;
 public class PhotoGenerationMetrics implements AIMetrics{
 
     private final MeterRegistry meterRegistry;
+    private Counter successCounter;
+    private Counter failCounter;
+
+    @PostConstruct
+    public void init() {
+        this.successCounter = Counter.builder("openai.image.success.count")
+                .description("Number of successful image generations")
+                .register(meterRegistry);
+
+        this.failCounter = Counter.builder("openai.image.fail.count")
+                .description("Number of failed image generations")
+                .register(meterRegistry);
+    }
 
     @Override
     public Timer.Sample start() {
@@ -18,8 +33,18 @@ public class PhotoGenerationMetrics implements AIMetrics{
 
     @Override
     public void stop(Timer.Sample sample) {
-        sample.stop(Timer.builder("openai.image.total")
+        sample.stop(Timer.builder("openai.image.latency")
                 .description("End-to-end latency for OpenAI image generation")
                 .register(meterRegistry));
     }
+
+    public void success() {
+        successCounter.increment();
+    }
+
+    public void fail() {
+        failCounter.increment();
+    }
+
+
 }

--- a/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
@@ -1,0 +1,25 @@
+package org.woojukang.remixlab.global.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PhotoGenerationMetrics implements AIMetrics{
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public Timer.Sample start() {
+        return Timer.start(meterRegistry);
+    }
+
+    @Override
+    public void stop(Timer.Sample sample) {
+        sample.stop(Timer.builder("openai.image.total")
+                .description("End-to-end latency for OpenAI image generation")
+                .register(meterRegistry));
+    }
+}

--- a/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/PhotoGenerationMetrics.java
@@ -1,28 +1,41 @@
 package org.woojukang.remixlab.global.metrics;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Component
 @RequiredArgsConstructor
 public class PhotoGenerationMetrics implements AIMetrics{
 
     private final MeterRegistry meterRegistry;
-    private Counter successCounter;
-    private Counter failCounter;
+
+    private final ConcurrentMap<String, AtomicInteger> inflightMap = new ConcurrentHashMap<>(); // flow 별 현재 처리중 요청 수 저장
+    private final ConcurrentMap<String, Counter> requestCounters = new ConcurrentHashMap<>(); // 요청 수 카운터 저장
+    private final ConcurrentMap<String, Timer> totalLatencyTimers = new ConcurrentHashMap<>(); // flow별 전체 latency timer 저장
+    private final ConcurrentMap<String, Timer> stageLatencyTimers = new ConcurrentHashMap<>(); // flow + stage별 latency timer 저장
 
     @PostConstruct
     public void init() {
-        this.successCounter = Counter.builder("openai.image.success.count")
-                .description("Number of successful image generations")
-                .register(meterRegistry);
+        registerInflightGauge("plot");
+        registerInflightGauge("direct");
+    }
 
-        this.failCounter = Counter.builder("openai.image.fail.count")
-                .description("Number of failed image generations")
+    private void registerInflightGauge(String flow) {
+        AtomicInteger inflight = new AtomicInteger(0);
+        inflightMap.put(flow, inflight);
+
+        Gauge.builder("openai.image.inflight", inflight, AtomicInteger::get)
+                .description("Number of in-flight image generation requests")
+                .tag("flow", flow)
                 .register(meterRegistry);
     }
 
@@ -32,19 +45,76 @@ public class PhotoGenerationMetrics implements AIMetrics{
     }
 
     @Override
-    public void stop(Timer.Sample sample) {
-        sample.stop(Timer.builder("openai.image.latency")
-                .description("End-to-end latency for OpenAI image generation")
-                .register(meterRegistry));
+    public void stopTotal(Timer.Sample sample, String flow) {
+        sample.stop(getOrCreateTotalTimer(flow));
     }
 
-    public void success() {
-        successCounter.increment();
+    @Override
+    public void stopStage(Timer.Sample sample, String flow, String stage) {
+        sample.stop(getOrCreateStageTimer(flow, stage));
     }
 
-    public void fail() {
-        failCounter.increment();
+    @Override
+    public void incrementRequest(String flow, String result) {
+        getOrCreateRequestCounter(flow, result).increment();
     }
 
+    @Override
+    public void incrementInflight(String flow) {
+        // 해당 flow의 진행 중 요청 수 증가
+        inflightMap.computeIfAbsent(flow, key -> {
+            AtomicInteger inflight = new AtomicInteger(0);
+            Gauge.builder("openai.image.inflight", inflight, AtomicInteger::get)
+                    .description("Number of in-flight image generation requests")
+                    .tag("flow", key)
+                    .register(meterRegistry);
+            return inflight;
+        }).incrementAndGet();
+    }
+
+    @Override
+    public void decrementInflight(String flow) {
+        // 해당 flow의 진행 중 요청 수 감소
+        AtomicInteger inflight = inflightMap.get(flow);
+        if (inflight != null) {
+            inflight.decrementAndGet();
+        }
+    }
+
+    private Counter getOrCreateRequestCounter(String flow, String result) {
+        // flow/result 조합별 counter를 재사용하기 위한 key
+        String key = flow + ":" + result;
+        return requestCounters.computeIfAbsent(key, k ->
+                Counter.builder("openai.image.requests")
+                        .description("Number of image generation requests")
+                        .tag("flow", flow)
+                        .tag("result", result)
+                        .register(meterRegistry)
+        );
+    }
+
+    private Timer getOrCreateTotalTimer(String flow) {
+        // flow별 total latency timer를 재사용
+        return totalLatencyTimers.computeIfAbsent(flow, k ->
+                Timer.builder("openai.image.latency")
+                        .description("End-to-end latency for image generation")
+                        .tag("flow", flow)
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
+    }
+
+    private Timer getOrCreateStageTimer(String flow, String stage) {
+        // flow별 total latency timer 재사용
+        String key = flow + ":" + stage;
+        return stageLatencyTimers.computeIfAbsent(key, k ->
+                Timer.builder("openai.image.stage.latency")
+                        .description("Stage latency for image generation")
+                        .tag("flow", flow)
+                        .tag("stage", stage)
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
+    }
 
 }

--- a/src/main/java/org/woojukang/remixlab/global/metrics/VideoGenerationMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/VideoGenerationMetrics.java
@@ -1,0 +1,26 @@
+package org.woojukang.remixlab.global.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VideoGenerationMetrics implements AIMetrics{
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public Timer.Sample start() {
+        return Timer.start(meterRegistry);
+    }
+
+    @Override
+    public void stop(Timer.Sample sample) {
+        sample.stop(Timer.builder("openai.video.total")
+                .description("End-to-end latency for OpenAI video generation")
+                .register(meterRegistry));
+
+    }
+}

--- a/src/main/java/org/woojukang/remixlab/global/metrics/VideoGenerationMetrics.java
+++ b/src/main/java/org/woojukang/remixlab/global/metrics/VideoGenerationMetrics.java
@@ -1,9 +1,16 @@
 package org.woojukang.remixlab.global.metrics;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Component
 @RequiredArgsConstructor
@@ -11,16 +18,97 @@ public class VideoGenerationMetrics implements AIMetrics{
 
     private final MeterRegistry meterRegistry;
 
+    private final ConcurrentMap<String, AtomicInteger> inflightMap = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Counter> requestCounters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Timer> totalLatencyTimers = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Timer> stageLatencyTimers = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    public void init() {
+        registerInflightGauge("photo_based");
+        registerInflightGauge("text_based");
+    }
+
+    private void registerInflightGauge(String flow) {
+        AtomicInteger inflight = new AtomicInteger(0);
+        inflightMap.put(flow, inflight);
+
+        Gauge.builder("openai.video.inflight", inflight, AtomicInteger::get)
+                .description("Number of in-flight video generation requests")
+                .tag("flow", flow)
+                .register(meterRegistry);
+    }
+
     @Override
     public Timer.Sample start() {
         return Timer.start(meterRegistry);
     }
 
     @Override
-    public void stop(Timer.Sample sample) {
-        sample.stop(Timer.builder("openai.video.total")
-                .description("End-to-end latency for OpenAI video generation")
-                .register(meterRegistry));
+    public void stopTotal(Timer.Sample sample, String flow) {
+        sample.stop(getOrCreateTotalTimer(flow));
+    }
 
+    @Override
+    public void stopStage(Timer.Sample sample, String flow, String stage) {
+        sample.stop(getOrCreateStageTimer(flow, stage));
+    }
+
+    @Override
+    public void incrementRequest(String flow, String result) {
+        getOrCreateRequestCounter(flow, result).increment();
+    }
+
+    @Override
+    public void incrementInflight(String flow) {
+        inflightMap.computeIfAbsent(flow, key -> {
+            AtomicInteger inflight = new AtomicInteger(0);
+            Gauge.builder("openai.video.inflight", inflight, AtomicInteger::get)
+                    .description("Number of in-flight video generation requests")
+                    .tag("flow", key)
+                    .register(meterRegistry);
+            return inflight;
+        }).incrementAndGet();
+    }
+
+    @Override
+    public void decrementInflight(String flow) {
+        AtomicInteger inflight = inflightMap.get(flow);
+        if (inflight != null) {
+            inflight.decrementAndGet();
+        }
+    }
+
+    private Counter getOrCreateRequestCounter(String flow, String result) {
+        String key = flow + ":" + result;
+        return requestCounters.computeIfAbsent(key, k ->
+                Counter.builder("openai.video.requests")
+                        .description("Number of video generation requests")
+                        .tag("flow", flow)
+                        .tag("result", result)
+                        .register(meterRegistry)
+        );
+    }
+
+    private Timer getOrCreateTotalTimer(String flow) {
+        return totalLatencyTimers.computeIfAbsent(flow, k ->
+                Timer.builder("openai.video.latency")
+                        .description("End-to-end latency for video generation")
+                        .tag("flow", flow)
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
+    }
+
+    private Timer getOrCreateStageTimer(String flow, String stage) {
+        String key = flow + ":" + stage;
+        return stageLatencyTimers.computeIfAbsent(key, k ->
+                Timer.builder("openai.video.stage.latency")
+                        .description("Stage latency for video generation")
+                        .tag("flow", flow)
+                        .tag("stage", stage)
+                        .publishPercentileHistogram()
+                        .register(meterRegistry)
+        );
     }
 }

--- a/src/main/java/org/woojukang/remixlab/global/security/service/RefreshService.java
+++ b/src/main/java/org/woojukang/remixlab/global/security/service/RefreshService.java
@@ -136,7 +136,7 @@ public class RefreshService {
 
     public void validateAlreadyLogin(String username){
 
-       if(!refreshRepository.exists(username)){
+       if(refreshRepository.exists(username)){
            throw new BaseException(BaseExceptionEnum.USER_ALREADY_LOGIN);
        }
     }

--- a/src/main/java/org/woojukang/remixlab/global/utils/ai/AiUtils.java
+++ b/src/main/java/org/woojukang/remixlab/global/utils/ai/AiUtils.java
@@ -25,6 +25,8 @@ import org.woojukang.remixlab.global.client.ai.dto.response.video.SoraResponse;
 import org.woojukang.remixlab.global.config.exception.BaseExceptionEnum;
 import org.woojukang.remixlab.global.config.exception.domain.BaseException;
 import org.woojukang.remixlab.query.creation.dto.response.ShowPlotWithDetailResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -41,22 +43,21 @@ public class AiUtils {
     private String soraModel;
 
     // LLM API의 결과를 String 타입으로 변환
-    public String getJsonText(String model,
-                               AiClientRequest request) {
+    public Mono<String> getJsonText(String model,
+                                    AiClientRequest request) {
 
-        GptResponse gptResponse = gptClient.sendMessage(
-                new GptRequest(model, request.prompt())
-        );
-
-        return gptResponse.output()
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new BaseException(BaseExceptionEnum.LLM_API_RESPONSE_NOT_FOUND))
-                .content()
-                .stream()
-                .findFirst()
-                .orElseThrow(() -> new BaseException(BaseExceptionEnum.LLM_API_RESPONSE_NOT_FOUND))
-                .text();
+        return gptClient.sendMessage(
+                        new GptRequest(model, request.prompt())
+                )
+                .map(gptResponse -> gptResponse.output()
+                        .stream()
+                        .findFirst()
+                        .orElseThrow()
+                        .content()
+                        .stream()
+                        .findFirst()
+                        .orElseThrow()
+                        .text());
     }
 
 
@@ -72,61 +73,58 @@ public class AiUtils {
         }
     }
 
-
     // DALLE API을 병렬 호출 ( 5회 )
-    @Async("dalleExecutor")
-    public CompletableFuture<InitPhotoRenderResponse> makePhotos
-            (InitPhotoRenderRequest request){
+    public Mono<InitPhotoRenderResponse> makePhotos(
+            InitPhotoRenderRequest request) {
 
-        List<CompletableFuture<InitPhotoRenderResponse.Images>> futures =
-                request.imagePrompts()
-                        .stream()
-                        .map(detail -> CompletableFuture.supplyAsync(()->{
+        return Flux.fromIterable(request.imagePrompts())
 
-                            DALLERequest dalleRequest = new DALLERequest(
-                                    "gpt-image-1",
-                                    detail.prompt(),
-                                    "1024x1024"
+                .flatMap(detail -> {
+
+                    DALLERequest dalleRequest = new DALLERequest(
+                            "gpt-image-1",
+                            detail.prompt(),
+                            "1024x1024"
+                    );
+
+                    return gptClient.makeImage(dalleRequest)
+                            .map(dalleResponse ->
+                                    new InitPhotoRenderResponse.Images(
+                                            String.valueOf(detail.sceneNumber()),
+                                            dalleResponse.data().get(0).b64_json()
+                                    )
                             );
+                })
 
-                            DALLEResponse dalleResponse = gptClient.makeImage(dalleRequest);
+                // 여기서 모든 결과 모음 (CompletableFuture.allOf 역할)
+                .collectList()
 
-                            return new InitPhotoRenderResponse.Images(
-                                    String.valueOf(detail.sceneNumber()),
-                                    dalleResponse.data().get(0).b64_json()
-                            );
-
-                        })).toList();
-
-        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-                .thenApply(v->futures.stream()
-                        .map(CompletableFuture::join)
-                        .toList())
-                .thenApply(InitPhotoRenderResponse::new);
-
+                // List<Images> → InitPhotoRenderResponse
+                .map(InitPhotoRenderResponse::new);
     }
 
-    public DirectPhotoResponse makePhotoFromText(DirectPhotoRequest request){
+
+    public Mono<DirectPhotoResponse> makePhotoFromText(DirectPhotoRequest request){
 
         DALLERequest dalleRequest = new DALLERequest(
                 "gpt-image-1",
-                request.prompt(),  // 텍스트 입력
+                request.prompt(),
                 "auto"
         );
 
-        DALLEResponse dalleResponse = gptClient.makeImage(dalleRequest);
+        return gptClient.makeImage(dalleRequest)
+                .map(dalleResponse -> {
 
-        // 한 개만 나오므로 data.get(0) 접근
-        String base64Image = dalleResponse
-                .data()
-                .get(0)
-                .b64_json();
+                    String base64Image = dalleResponse
+                            .data()
+                            .get(0)
+                            .b64_json();
 
-        return new DirectPhotoResponse(base64Image);
-
+                    return new DirectPhotoResponse(base64Image);
+                });
     }
 
-    public SoraResponse makeVideoFromPhotos(ShowPlotWithDetailResponse showPlotWithDetailResponse){
+    public Mono<SoraResponse> makeVideoFromPhotos(ShowPlotWithDetailResponse showPlotWithDetailResponse){
 
 
         String json;
@@ -151,7 +149,7 @@ public class AiUtils {
 
     }
 
-    public SoraResponse makeVideoByText(DirectVideoRequest directVideoRequest){
+    public Mono<SoraResponse> makeVideoByText(DirectVideoRequest directVideoRequest){
 
         SoraRequest soraRequest = new SoraRequest(soraModel,
                 directVideoRequest.prompt(),

--- a/src/main/java/org/woojukang/remixlab/query/user/service/UserQueryService.java
+++ b/src/main/java/org/woojukang/remixlab/query/user/service/UserQueryService.java
@@ -13,7 +13,6 @@ import org.woojukang.remixlab.query.user.repository.UserQueryRepository;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class UserQueryService {
 
     private final UserQueryRepository userQueryRepository;

--- a/src/main/resources/application-common-local.yml
+++ b/src/main/resources/application-common-local.yml
@@ -63,3 +63,14 @@ openai:
     soraStatus: https://api.openai.com/v1/videos/{id}
     soraDownload: https://api.openai.com/v1/videos/
 
+management:
+  server:
+    port: 9292
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,info,loggers,prometheus
+  endpoint:
+    health:
+      show-details: always
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,7 +2,7 @@ spring:
   application:
     name: remixLab-api
   profiles:
-    active: test
+    active: local
     group:
       test: common-test
       local: common-local


### PR DESCRIPTION
## 📌 Related Issue

- Close #3

---

## 💬 Description

Refactored the external AI API integration from a blocking model (`RestTemplate` + `@Async/CompletableFuture`) to a reactive pipeline using `WebClient` and Reactor.

### Changes

- Replaced `RestTemplate` with `WebClient` for external AI API calls
- Converted AI generation flows (photo, video, plot) to reactive `Mono`-based pipelines
- Updated controllers to return `Mono<ResponseEntity<ApiResult<...>>>`
- Separated blocking persistence logic into dedicated `PersistenceFacade` classes
- Isolated blocking JPA/QueryDSL operations using:
  - `Mono.fromCallable(...)`
  - `Schedulers.boundedElastic()`
- Resolved `@Transactional` self-invocation issues by moving transactional logic into separate beans
- Extended reactive flow across service and facade layers
- Added Micrometer-based metrics for observability:
  - Total latency
  - Stage latency
  - In-flight request tracking
  - Success / failure counters
  - Flow-based tagging
- Redesigned `AIMetrics` interface to support detailed observability
- Configured `maxInMemorySize` for WebClient

---

## 📢 Notes

- Quantitative comparison with the previous implementation is limited due to the absence of metrics
- This refactor focuses on improving structure, concurrency handling, and observability
- JPA/QueryDSL remains blocking; persistence is isolated using `boundedElastic` to prevent event-loop blocking